### PR TITLE
Change input_path for CodeSignatureVerifier

### DIFF
--- a/Docker/Docker.download.recipe
+++ b/Docker/Docker.download.recipe
@@ -45,7 +45,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Docker.app</string>
                 <key>requirement</key>
                 <string>anchor apple generic and identifier "com.docker.docker" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9BNSXJN65R")</string>
             </dict>


### PR DESCRIPTION
While a Munki admin can customize the NAME to fit their item naming scheme, that chosen name should not be expected to be the name of the app on the DockerForMac disk image. Instead CodeSignatureVerifier needs to verify the actual app as it is named on the the disk image, currently "Docker.app".
