### PR TITLE
Use Docker's app bundle instead of Sparkle feed for version info

### DIFF
--- a/Docker/Docker.download.recipe
+++ b/Docker/Docker.download.recipe
@@ -52,6 +52,17 @@
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
         </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_plist_path</key>
+                <string>%pathname%/Docker.app/Contents/Info.plist</string>
+                <key>plist_version_key</key>
+                <string>CFBundleShortVersionString</string>
+            </dict>
+            <key>Processor</key>
+            <string>Versioner</string>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Looks like the latest Sparkle feed now has a version like `<version> (<build>)`. This PR does a versioning step as part of the download so that both the pkg and munki child recipes have a cleaner `%version%` value to substitute in.