### PR TITLE
Prevent Docker asking for admin password on launch

### DIFF
--- a/Docker/Docker.munki.recipe
+++ b/Docker/Docker.munki.recipe
@@ -53,6 +53,11 @@ done
 /usr/bin/install -m 0544 -o root -g wheel ${docker_bundle_dir}/Library/LaunchServices/com.docker.vmnetd ${privtools}
 /usr/bin/install -m 0644 -o root -g wheel ${docker_bundle_dir}/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons
 
+VERSION=$(/usr/bin/defaults read /Applications/Docker.app/Contents/Info.plist VmnetdVersion)
+/usr/bin/defaults write /Library/LaunchDaemons/com.docker.vmnetd.plist Version -string ${VERSION}
+/usr/bin/plutil -convert xml1 /Library/LaunchDaemons/com.docker.vmnetd.plist
+/bin/chmod 0644 /Library/LaunchDaemons/com.docker.vmnetd.plist
+
 /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
             ]]></string>
             <key>postuninstall_script</key>


### PR DESCRIPTION
Docker 17.12 (apparently) requires that a 'Version' key is present in /Library/LaunchDaemons/com.docker.vmnetd.plist. If it isn't, it will request an admin password on launch to put it in (in our environment regular users don't know the admin password, so being able to install apps without having to type in the admin password at launch is a strict requirement). Adding the version beforehand to /Library/LaunchDaemons/com.docker.vmnetd.plist allows Docker to start without asking for admin credentials. It also looks like the version you need to put in, is the one that is listed as value for the 'VmnetdVersion' key from Docker's Info.plist. The suggested change adds a few lines to the Docker postinstall script in the munki recipe, to extract the version from Info.plist, and add an extra key/value pair to the com.docker.vmnetd.plist launchd job. It's possible that there are better ways to do this, but this fix seems to work in our environment.

I suppose a similar change can be made to [scripts/postinstall](https://github.com/autopkg/chilcote-recipes/blob/master/Docker/scripts/postinstall), but I have no means of testing that fix atm, so I've not copied it to that file.