### PR TITLE
Using FindandReplace processor; postinstall update

### DIFF
--- a/Docker/Docker.pkg.recipe
+++ b/Docker/Docker.pkg.recipe
@@ -46,48 +46,52 @@
             <key>Processor</key>
             <string>Copier</string>
         </dict>
-        <dict>     
-          <key>Processor</key>
-          <string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
-          <key>Arguments</key>
-          <dict>
-            <key>split_on</key>
-            <string>-</string>
-          </dict>     
-        </dict>
-          <dict>
+        <dict>
             <key>Arguments</key>
             <dict>
-                <key>pkg_request</key>
-                <dict>
-                    <key>chown</key>
-                    <array>
-                        <dict>
-                            <key>group</key>
-                            <string>admin</string>
-                            <key>path</key>
-                            <string>Applications</string>
-                            <key>user</key>
-                            <string>root</string>
-                        </dict>
-                    </array>
-                    <key>id</key>
-                    <string>%BUNDLE_ID%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
-                    <key>pkgname</key>
-                    <string>%NAME%-%version%</string>
-                    <key>pkgroot</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                    <key>version</key>
-                    <string>%version%</string>
-                    <key>scripts</key>
-                    <string>scripts</string>
-                </dict>
+                <key>find</key>
+                <string>-ce-mac</string>
+                <key>input_string</key>
+                <string>%version%</string>
+                <key>replace</key>
+                <string>.</string>
             </dict>
             <key>Processor</key>
-            <string>PkgCreator</string>
+            <string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
         </dict>
+        <dict>
+        <key>Arguments</key>
+        <dict>
+            <key>pkg_request</key>
+            <dict>
+                <key>chown</key>
+                <array>
+                    <dict>
+                        <key>group</key>
+                        <string>admin</string>
+                        <key>path</key>
+                        <string>Applications</string>
+                        <key>user</key>
+                        <string>root</string>
+                    </dict>
+                </array>
+                <key>id</key>
+                <string>%BUNDLE_ID%</string>
+                <key>options</key>
+                <string>purge_ds_store</string>
+                <key>pkgname</key>
+                <string>%NAME%-%output_string%</string>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>version</key>
+                <string>%output_string%</string>
+                <key>scripts</key>
+                <string>scripts</string>
+            </dict>
+        </dict>
+        <key>Processor</key>
+        <string>PkgCreator</string>
+    </dict>
     </array>
 </dict>
 </plist>

--- a/Docker/scripts/postinstall
+++ b/Docker/scripts/postinstall
@@ -19,4 +19,8 @@ done
 
 [[ $3 != "/" ]] && exit 0
 
+VERSION=$(/usr/bin/defaults read /Applications/Docker.app/Contents/Info.plist VmnetdVersion)
+/usr/bin/defaults write /Library/LaunchDaemons/com.docker.vmnetd.plist Version -string ${VERSION}
+/usr/bin/plutil -convert xml1 /Library/LaunchDaemons/com.docker.vmnetd.plist
+/bin/chmod 0644 /Library/LaunchDaemons/com.docker.vmnetd.plist
 /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist


### PR DESCRIPTION
With VersionSplitter, minor version would drop, so releases 17.12.0-ce-mac49 and 17.12.0-ce-mac55 would both be repackaged to Docker-17.12.0.pkg, which would be seen as no change.

Now replaces -ce-mac with . so this example would package as Docker-17.12.0.55.pkg.

Also rolled in the change that gerardkok make to the Munki recipe into the postinstall so user doesn't get prompted for admin credentials.