### PR TITLE
changed FindAndReplace search string to "-mac"

### DIFF
--- a/Docker/Docker.pkg.recipe
+++ b/Docker/Docker.pkg.recipe
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>find</key>
-                <string>-ce-mac</string>
+                <string>-mac</string>
                 <key>input_string</key>
                 <string>%version%</string>
                 <key>replace</key>


### PR DESCRIPTION
Updated FindAndReplace processor search string from "-ce-mac" to "-mac" to match the current Sparkle feed versioning syntax for `sparkle:shortVersionString`.