### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Docker/Docker.install.recipe
+++ b/Docker/Docker.install.recipe
@@ -30,7 +30,7 @@
                         <key>destination_path</key>
                         <string>/Applications</string>
                         <key>source_item</key>
-                        <string>%NAME%.app</string>
+                        <string>Docker.app</string>
                     </dict>
                 </array>
             </dict>

--- a/Docker/Docker.pkg.recipe
+++ b/Docker/Docker.pkg.recipe
@@ -39,9 +39,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/Docker.app</string>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/Docker.app</string>
             </dict>
             <key>Processor</key>
             <string>Copier</string>

--- a/JetBrains/CLion.pkg.recipe
+++ b/JetBrains/CLion.pkg.recipe
@@ -37,9 +37,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/CLion.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/CLion.app</string>
             </dict>
         </dict>
         <dict>
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/CLion.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/JetBrains/PyCharm.pkg.recipe
+++ b/JetBrains/PyCharm.pkg.recipe
@@ -37,9 +37,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/PyCharm.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/PyCharm.app</string>
             </dict>
         </dict>
         <dict>
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/PyCharm.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>

--- a/JetBrains/WebStorm.pkg.recipe
+++ b/JetBrains/WebStorm.pkg.recipe
@@ -37,9 +37,9 @@
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%pathname%/%NAME%.app</string>
+                <string>%pathname%/WebStorm.app</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app</string>
+                <string>%pkgroot%/Applications/WebStorm.app</string>
             </dict>
         </dict>
         <dict>
@@ -50,7 +50,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+                <string>%pkgroot%/Applications/WebStorm.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleShortVersionString</string>
             </dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.