### PR TITLE
Add CodeSignatureVerifier processor

### DIFF
--- a/JetBrains/CLion.download.recipe
+++ b/JetBrains/CLion.download.recipe
@@ -34,6 +34,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/CLion.app</string>
+                <key>requirements</key>
+                <string>identifier "com.jetbrains.CLion" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Context: The [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Using-CodeSignatureVerification) processor ensures that the downloaded applications/packages are signed by the expected developer certificate. Although this is not a guarantee that the payload is trouble-free, it's a good indicator that the file you downloaded is the one you intended to download.