### PR TITLE
Update postinstall_script

### DIFF
--- a/Docker/Docker.munki.recipe
+++ b/Docker/Docker.munki.recipe
@@ -52,6 +52,11 @@ done
 
 [[ ! -d ${privtools} ]] && /bin/mkdir -p ${privtools} ; /bin/chmod 1755 ${privtools}
 
+# unload com.docker.vmnetd if present
+if [[ -e /Library/LaunchDaemons/com.docker.vmnetd.plist ]] ; then
+    /bin/launchctl unload /Library/LaunchDaemons/com.docker.vmnetd.plist
+fi
+
 /usr/bin/install -m 0544 -o root -g wheel ${docker_bundle_dir}/Library/LaunchServices/com.docker.vmnetd ${privtools}
 /usr/bin/install -m 0644 -o root -g wheel ${docker_bundle_dir}/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons
 


### PR DESCRIPTION
If /Library/LaunchDaemons/com.docker.vmnetd.plist exists, unload it before installing the new copy.
This addresses an issue when launching Docker.app ("Fatal Error The operation couldn't be completed. (DockerVmnetdError error1.)") after upgrading from 2.3.0.3 to 2.3.0.4 (and presumably any other time this LaunchDaemon changes between releases).