### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/JetBrains/CLion.download.recipe
+++ b/JetBrains/CLion.download.recipe
@@ -41,7 +41,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/CLion.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "com.jetbrains.CLion" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>
         </dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.